### PR TITLE
v0.3.0

### DIFF
--- a/lib/ProcessMemory.rb
+++ b/lib/ProcessMemory.rb
@@ -40,7 +40,7 @@ module ProcessMemory
   # TODO: ファイナライザ
   # ProcessMemory External
   class ProcessMemoryEx
-    @@i_am_x64 = WinMemAPI::SIZEOF_PTR == 8
+    I_am_x64 = WinMemAPI::SIZEOF_PTR == 8
 
     # コンストラクタ
     # @param [Integer] pid プロセスID
@@ -129,6 +129,7 @@ module ProcessMemory
 
       result = lphModule.unpack('V*')
       if @@i_am_x64
+      if I_am_x64
         # hostが64bitの場合 ポインタサイズが64bitなので一気に変換はできない
         result = result.each_slice(2).map{|l, h|
           h << 32 | l

--- a/lib/ProcessMemory.rb
+++ b/lib/ProcessMemory.rb
@@ -64,7 +64,7 @@ module ProcessMemory
       @pid       = pid
       @h_process = WinMemAPI.OpenProcess(WinMemAPI::OpenProcFlg::READ_INFO, 0, pid)
       # オープン失敗
-      raise ArgumentError, "process open failed. pid:#{@pid}" if @h_process == 0
+      raise ArgumentError, "process open failed. pid:#{@pid}" if @h_process.zero?
 
       @target_is_x64 = detect_x64
 
@@ -116,7 +116,7 @@ module ProcessMemory
       lpcb_needed = "\0\0\0\0\0\0\0\0".b
 
       WinMemAPI.EnumProcessModulesEx(@h_process, 0, 0, lpcb_needed, WinMemAPI::EnumFilterFlg::LIST_MODULES_32BIT)
-      (lpcb_needed.unpack('V')[0]) == 0
+      (lpcb_needed.unpack('V')[0]).zero?
     end
 
     def modules_read
@@ -131,7 +131,7 @@ module ProcessMemory
       if (len = lpcb_needed.unpack('V')[0]) > initial_len
         lph_module = "\0" * len
         WinMemAPI.EnumProcessModulesEx(@h_process, lph_module, len, lpcb_needed, flg)
-      elsif len == 0
+      elsif len.zero?
         # 失敗
         return nil
       end
@@ -148,7 +148,7 @@ module ProcessMemory
       @main_module_addr ||= result[0]
 
       # GetModuleBaseNameでベース名を取得する
-      result.select{|it| it != 0 }.map{|it|
+      result.select(&:nonzero?).map{|it|
         namelen = 260
         namebuf = "\0".encode(Encoding::UTF_16LE) * namelen
         result_len = WinMemAPI.GetModuleBaseNameW(@h_process, it, namebuf, namelen)

--- a/lib/ProcessMemory.rb
+++ b/lib/ProcessMemory.rb
@@ -51,6 +51,11 @@ module ProcessMemory
         }
       end
 
+      # 直前に開いたProcessMemoryExを返す
+      def latest
+        # 子孫クラスからも書き換えられる事を想定しているのでクラス変数を使う
+        @@latest
+      end
     end
 
     # コンストラクタ

--- a/lib/ProcessMemory.rb
+++ b/lib/ProcessMemory.rb
@@ -37,11 +37,8 @@ module ProcessMemory
     end
   end
 
-=begin
-OpenProcessで取得したハンドルを閉じてないが
-ファイナライザで開放した方がいいかも？(大量にオープンしない限り問題は起きないはず)
-適当解放処理実装した
-=end
+  # TODO: ファイナライザ
+  # ProcessMemory External
   class ProcessMemoryEx
     @@i_am_x64 = WinMemAPI::SIZEOF_PTR == 8
 

--- a/lib/ProcessMemory.rb
+++ b/lib/ProcessMemory.rb
@@ -51,6 +51,8 @@ module ProcessMemory
         }
       end
 
+    end
+
     # コンストラクタ
     # @param [Integer] pid プロセスID
     def initialize(pid)

--- a/lib/ProcessMemory.rb
+++ b/lib/ProcessMemory.rb
@@ -100,24 +100,24 @@ module ProcessMemory
     # true => 64bit process
     # false => 32bit process
     def detect_x64
-      lpcbNeeded = "\0\0\0\0\0\0\0\0".b
+      lpcb_needed = "\0\0\0\0\0\0\0\0".b
 
-      WinMemAPI.EnumProcessModulesEx(@h_process, 0, 0, lpcbNeeded, WinMemAPI::EnumFilterFlg::LIST_MODULES_32BIT)
-      (lpcbNeeded.unpack('V')[0]) == 0
+      WinMemAPI.EnumProcessModulesEx(@h_process, 0, 0, lpcb_needed, WinMemAPI::EnumFilterFlg::LIST_MODULES_32BIT)
+      (lpcb_needed.unpack('V')[0]) == 0
     end
 
     def modules_read
       len = 32 * WinMemAPI::SIZEOF_PTR
       initial_len = len
-      lphModule = "\0" * len
-      lpcbNeeded = "\0\0\0\0\0\0\0\0".b
+      lph_module = "\0" * len
+      lpcb_needed = "\0\0\0\0\0\0\0\0".b
       # 対象プロセスが64bitの場合は変更する
       flg = @target_is_x64 ? WinMemAPI::EnumFilterFlg::LIST_MODULES_64BIT : WinMemAPI::EnumFilterFlg::LIST_MODULES_32BIT
 
-      WinMemAPI.EnumProcessModulesEx(@h_process, lphModule, len, lpcbNeeded, flg)
-      if (len = lpcbNeeded.unpack('V')[0]) > initial_len
-        lphModule = "\0" * len
-        WinMemAPI.EnumProcessModulesEx(@h_process, lphModule, len, lpcbNeeded, flg)
+      WinMemAPI.EnumProcessModulesEx(@h_process, lph_module, len, lpcb_needed, flg)
+      if (len = lpcb_needed.unpack('V')[0]) > initial_len
+        lph_module = "\0" * len
+        WinMemAPI.EnumProcessModulesEx(@h_process, lph_module, len, lpcb_needed, flg)
       elsif len == 0 && !@target_is_x64
         # ターゲットはおそらく64bit(もしくは権限不足,openに失敗)
         @target_is_x64 = true
@@ -127,8 +127,7 @@ module ProcessMemory
         return nil
       end
 
-      result = lphModule.unpack('V*')
-      if @@i_am_x64
+      result = lph_module.unpack('V*')
       if I_am_x64
         # hostが64bitの場合 ポインタサイズが64bitなので一気に変換はできない
         result = result.each_slice(2).map{|l, h|

--- a/lib/ProcessMemory.rb
+++ b/lib/ProcessMemory.rb
@@ -176,20 +176,22 @@ module ProcessMemory
       modules.select{|_, v| v == name }.sort[0][0]
     end
 
-    def self.ptr(addr)
-      @@latest.ptr addr
-    end
+    class << self
+      def ptr(addr)
+        latest.ptr addr
+      end
 
-    def self.ptr_buf(addr, size)
-      @@latest.ptr_buf addr, size
-    end
+      def ptr_buf(addr, size)
+        latest.ptr_buf addr, size
+      end
 
-    def self.ptr_fmt(addr, size, fmt)
-      @@latest.ptr_fmt addr, size, fmt
-    end
+      def ptr_fmt(addr, size, fmt)
+        latest.ptr_fmt addr, size, fmt
+      end
 
-    def self.MName(name) # rubocop:disable Style/MethodName
-      @@latest.MName name
+      def MName(name) # rubocop:disable Style/MethodName
+        latest.MName name
+      end
     end
   end # End of class ProcessMemoryEx
 

--- a/lib/ProcessMemory.rb
+++ b/lib/ProcessMemory.rb
@@ -52,7 +52,7 @@ module ProcessMemory
 
       @target_is_x64 = detect_x64
 
-      @@latest = self
+      @@latest = self # rubocop:disable Style/ClassVars
 
       # 一応解放処理
       at_exit{

--- a/lib/ProcessMemory.rb
+++ b/lib/ProcessMemory.rb
@@ -118,10 +118,6 @@ module ProcessMemory
       if (len = lpcb_needed.unpack('V')[0]) > initial_len
         lph_module = "\0" * len
         WinMemAPI.EnumProcessModulesEx(@h_process, lph_module, len, lpcb_needed, flg)
-      elsif len == 0 && !@target_is_x64
-        # ターゲットはおそらく64bit(もしくは権限不足,openに失敗)
-        @target_is_x64 = true
-        return modules_read
       elsif len == 0
         # 失敗
         return nil

--- a/lib/ProcessMemory.rb
+++ b/lib/ProcessMemory.rb
@@ -1,5 +1,6 @@
 # coding: utf-8
 require 'ProcessMemory/version'
+require 'ProcessMemory/util'
 require 'fiddle/import'
 require 'fiddle/types'
 
@@ -37,7 +38,6 @@ module ProcessMemory
     end
   end
 
-  # TODO: ファイナライザ
   # ProcessMemory External
   class ProcessMemoryEx
     I_am_x64 = WinMemAPI::SIZEOF_PTR == 8
@@ -200,46 +200,5 @@ module ProcessMemory
     def MName(name) # rubocop:disable Style/MethodName
       modules.select{|_, v| v == name }.sort[0][0]
     end
-
-    class << self
-      def ptr(addr)
-        latest.ptr addr
-      end
-
-      def ptr_buf(addr, size)
-        latest.ptr_buf addr, size
-      end
-
-      def ptr_fmt(addr, size, fmt)
-        latest.ptr_fmt addr, size, fmt
-      end
-
-      def MName(name) # rubocop:disable Style/MethodName
-        latest.MName name
-      end
-    end
   end # End of class ProcessMemoryEx
-
-  # ユーティリティーモジュール
-  # includeする事で、省略記法が使えるようになる
-  module ProcessMemoryUtil
-    module_function def ptr(addr)
-      ProcessMemoryEx.ptr addr
-    end
-
-    module_function def MName(name) # rubocop:disable Style/MethodName
-      ProcessMemoryEx.MName name
-    end
-
-    module_function def memoryutil_startup
-      if ARGV.empty?
-        puts '対象exeのpidを入力してください'
-        s = gets.chop
-      else
-        s = ARGV[0]
-      end
-
-      ProcessMemoryEx.new s.to_i 0
-    end
-  end # End of Module ProcessMemoryUtil
 end # End of Module ProcessMemory

--- a/lib/ProcessMemory/util.rb
+++ b/lib/ProcessMemory/util.rb
@@ -1,0 +1,45 @@
+module ProcessMemory
+  # ProcessMemoryExに幾つか追加
+  class ProcessMemoryEx
+    class << self
+      def ptr(addr)
+        latest.ptr addr
+      end
+
+      def ptr_buf(addr, size)
+        latest.ptr_buf addr, size
+      end
+
+      def ptr_fmt(addr, size, fmt)
+        latest.ptr_fmt addr, size, fmt
+      end
+
+      def MName(name) # rubocop:disable Style/MethodName
+        latest.MName name
+      end
+    end
+  end # End of class ProcessMemoryEx
+
+  # ユーティリティーモジュール
+  # includeする事で、省略記法が使えるようになる
+  module ProcessMemoryUtil
+    module_function def ptr(addr)
+      ProcessMemoryEx.ptr addr
+    end
+
+    module_function def MName(name) # rubocop:disable Style/MethodName
+      ProcessMemoryEx.MName name
+    end
+
+    module_function def memoryutil_startup
+      if ARGV.empty?
+        puts '対象exeのpidを入力してください'
+        s = gets.chop
+      else
+        s = ARGV[0]
+      end
+
+      ProcessMemoryEx.new s.to_i 0
+    end
+  end # End of Module ProcessMemoryUtil
+end # End of Module ProcessMemory

--- a/lib/ProcessMemory/version.rb
+++ b/lib/ProcessMemory/version.rb
@@ -1,3 +1,3 @@
 module ProcessMemory
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.3.0'.freeze
 end

--- a/spec/ProcessMemory_spec.rb
+++ b/spec/ProcessMemory_spec.rb
@@ -58,6 +58,36 @@ describe ProcessMemory do
     end
   end # End of describe '#ptr_fmt'
 
+  describe '#strdup' do
+    teststr = 'alphabet/日本語まじり表現の恐怖'
+    it 'read utf8 string' do
+      expect(mem.strdup(Fiddle::Pointer[teststr.encode(Encoding::UTF_8)])).to eq teststr
+    end
+    it 'read utf16 string' do
+      expect(mem.strdup(Fiddle::Pointer[teststr.encode(Encoding::UTF_16)], atomic_size: 2)).to eq teststr
+    end
+    it 'read cp932 string' do
+      expect(mem.strdup(Fiddle::Pointer[teststr.encode(Encoding::CP932)], encoding: Encoding::CP932)).to eq teststr
+    end
+    it 'read from cp932 to utf8' do
+      expect(
+        mem.strdup(Fiddle::Pointer[teststr.encode(Encoding::CP932)], encoding: Encoding::CP932).encoding
+      ).to eq Encoding::UTF_8
+    end
+    it 'read from cp932 to utf16' do
+      expect(
+        mem.strdup(Fiddle::Pointer[teststr.encode(Encoding::CP932)],
+                   encoding: Encoding::CP932, encode: Encoding::UTF_16).encoding
+      ).to eq Encoding::UTF_16
+    end
+    it 'bad case, \0 into string' do
+      badteststr = "alphabet日本語まじり\0表現の恐怖"
+      expect(
+        mem.strdup(Fiddle::Pointer[badteststr.encode(Encoding::UTF_8)])
+      ).to_not eq badteststr
+    end
+  end
+
   describe ProcessMemory::ProcessMemoryUtil do
     before :all do
       ProcessMemory::ProcessMemoryEx.new Process.pid

--- a/spec/ProcessMemory_spec.rb
+++ b/spec/ProcessMemory_spec.rb
@@ -57,4 +57,16 @@ describe ProcessMemory do
       expect(mem.ptr_fmt(testp, testp.size, 'qq')).to eq(test_data)
     end
   end # End of describe '#ptr_fmt'
+
+  describe ProcessMemory::ProcessMemoryUtil do
+    before :all do
+      ProcessMemory::ProcessMemoryEx.new Process.pid
+    end
+    describe '.ptr' do
+      it 'read int32' do
+        testp = Fiddle::Pointer[[TESTINT32].pack('q')]
+        expect(ProcessMemory::ProcessMemoryUtil.ptr(testp)).to eq(TESTINT32)
+      end
+    end
+  end
 end # describe ProcessMemory

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'ProcessMemory'
 Encoding.default_external = 'UTF-8'
+puts "ProcessMemory::VERSION = #{ProcessMemory::VERSION}"


### PR DESCRIPTION
- Rubocopを黙らせた
- ProcessMemoryEx#strdupの追加
  \0終端文字列を読み取る
  - encodingオプションで読み取りエンコードを指定できる(デフォルトはUTFのどれか)
  - encodeオプションで書き出しエンコードを指定できる(デフォルトはutf8)
  - atomic_sizeオプションで読み出し単位を指定できる(1byte 2byte 4byteのいずれかのみ)
- ProcessMemoryEx.latestの追加
  直前に開いたProcessMemoryExのインスタンスを取得する