### PR TITLE
fix ProcessMemoryEx#ptr_fmt

### DIFF
--- a/lib/ProcessMemory.rb
+++ b/lib/ProcessMemory.rb
@@ -91,7 +91,7 @@ module ProcessMemory
     # @return 指定アドレスを読み込んだ結果にunpackしたもの もしsizeが1以下の場合は最初の要素を返す
     def ptr_fmt(addr, size, fmt)
       ary = ptr_buf(addr, size).unpack(fmt)
-      ary.size == 1 ? ary[0] : ary
+      fmt[-1] != '*' && ary.size == 1 ? ary[0] : ary
     end
 
     # 指定アドレスから4byteもしくは8byte読み込みリトルエンディアンの整数とみなした結果を返す

--- a/spec/ProcessMemory_spec.rb
+++ b/spec/ProcessMemory_spec.rb
@@ -56,6 +56,14 @@ describe ProcessMemory do
       testp = Fiddle::Pointer[test_data.pack('qq')]
       expect(mem.ptr_fmt(testp, testp.size, 'qq')).to eq(test_data)
     end
+    describe 'fmt suffix = *' do
+      testp = Fiddle::Pointer[[TESTINT64].pack('q')]
+      subject{ mem.ptr_fmt(testp, 8, 'q*') }
+      it 'should be instance of Array' do
+        is_expected.to be_instance_of(Array)
+        is_expected.to eq [TESTINT64]
+      end
+    end
   end # End of describe '#ptr_fmt'
 
   describe '#strdup' do


### PR DESCRIPTION
fmt文字列の末尾が*の時はサイズが1でも配列として読み取る