### PR TITLE
v0.3.1

### DIFF
--- a/lib/ProcessMemory.rb
+++ b/lib/ProcessMemory.rb
@@ -91,7 +91,7 @@ module ProcessMemory
     # @return 指定アドレスを読み込んだ結果にunpackしたもの もしsizeが1以下の場合は最初の要素を返す
     def ptr_fmt(addr, size, fmt)
       ary = ptr_buf(addr, size).unpack(fmt)
-      ary.size == 1 ? ary[0] : ary
+      fmt[-1] != '*' && ary.size == 1 ? ary[0] : ary
     end
 
     # 指定アドレスから4byteもしくは8byte読み込みリトルエンディアンの整数とみなした結果を返す

--- a/lib/ProcessMemory/util.rb
+++ b/lib/ProcessMemory/util.rb
@@ -1,6 +1,12 @@
 module ProcessMemory
   # ProcessMemoryExに幾つか追加
   class ProcessMemoryEx
+    # inspect modulesを入れるとあまりに長いので隠す
+    def inspect
+      # #<ProcessMemory::ProcessMemoryEx:0x000000029dc158 @pid=13508, @h_process=160, @target_is_x64=true>x
+      format("\#<#{self.class.name}:%0#{I_am_x64 ? 16 : 8}x @pid=#{@pid}, @h_process=#{@h_process}," \
+      " @target_is_x64=#{@target_is_x64}>", __id__)
+    end
     class << self
       def ptr(addr)
         latest.ptr addr

--- a/lib/ProcessMemory/version.rb
+++ b/lib/ProcessMemory/version.rb
@@ -1,3 +1,3 @@
 module ProcessMemory
-  VERSION = '0.4.0-develop'.freeze
+  VERSION = '0.3.1'.freeze
 end

--- a/lib/ProcessMemory/version.rb
+++ b/lib/ProcessMemory/version.rb
@@ -1,3 +1,3 @@
 module ProcessMemory
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.4.0-develop'.freeze
 end

--- a/spec/ProcessMemory_spec.rb
+++ b/spec/ProcessMemory_spec.rb
@@ -56,6 +56,14 @@ describe ProcessMemory do
       testp = Fiddle::Pointer[test_data.pack('qq')]
       expect(mem.ptr_fmt(testp, testp.size, 'qq')).to eq(test_data)
     end
+    describe 'fmt suffix = *' do
+      testp = Fiddle::Pointer[[TESTINT64].pack('q')]
+      subject{ mem.ptr_fmt(testp, 8, 'q*') }
+      it 'should be instance of Array' do
+        is_expected.to be_instance_of(Array)
+        is_expected.to eq [TESTINT64]
+      end
+    end
   end # End of describe '#ptr_fmt'
 
   describe '#strdup' do


### PR DESCRIPTION
- ProcessMemoryEx#inspectの改善
- ProcessMemoryEx#ptr_fmtの改善
  - fmt文字列が'*'で終わる場合、必ず配列を返すようにした
